### PR TITLE
Update hero btn

### DIFF
--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -27,7 +27,7 @@ export function Hero() {
                         Unlock Your Personalized Channel Bundle!
                     </h2>
 
-                    <Button className="buttons hero__btn" text="TAKE THE QUIZ NOW" handleClick={handleSubmit} />
+                    <Button className="buttons hero__btn" text="Take the Quiz Now" handleClick={handleSubmit} />
                 </div>
 
                 <div className="hero__carousel">

--- a/src/components/Hero/Hero.scss
+++ b/src/components/Hero/Hero.scss
@@ -63,17 +63,17 @@
 
     &__btn {
         max-width: 192px;
-        background-color: #2E073F;
-        color: white;
+        background-color: #FFFFFF;
+        color: forestgreen;
         font-weight: 400;
-        text-transform: uppercase;
         border-radius: 1.25rem;
-        border: none;
-        padding: 8px 24px;
+        border: .125rem solid transparent;
+        padding: 0.7rem 1.5rem 0.5rem 1.5rem;
 
         &:hover {
-            background-color: #8FD14F;
-            transition: 0.3s ease-in-out;
+            background-color: #FFFFFF;
+            border-color: forestgreen;
+            transition: border-color 0.3s ease-in-out;
         }
     }
 }


### PR DESCRIPTION
- Updated btn background colour and font colour to match the btn on Telus’ Optik TV website.
- Hovering also gives a green border, like on Telus.
- Updated the padding. Top padding, visually, was not the same as bottom padding
- Changed text from uppercase to just capitalizing the major words for the CTA button

![image](https://github.com/user-attachments/assets/78e2211e-7f1a-4b94-9f8b-1fd3b9d48eec)
